### PR TITLE
Basic x64 migration with performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ Project/MPLAB-*/RMP.X/.generated_files
 Project/MPLAB-*/RMP.X/disassembly
 Project/MPLAB-*/RMP.X/dist
 
+#VScode specific
 .cproject
 .project
 .vscode/c_cpp_properties.json
@@ -98,3 +99,10 @@ Project/MFGCC-XC7Z020/Object/RME.bin
 Project/MFGCC-XC7Z020/Object/RME.txt
 Project/MFGCC-XC7Z020/Object/start
 Project/MFGCC-XC7Z020/Object/USER.bin
+#VScode specific
+.vscode/
+Project/VSCODE-*/.vscode/c_cpp_properties.json
+
+#MacOS generated files
+.DS_Store
+

--- a/Include/Platform/X64/Profile/Super/rme_platform_x64_super.h
+++ b/Include/Platform/X64/Profile/Super/rme_platform_x64_super.h
@@ -24,6 +24,8 @@ Description: The configuration file for X64 supercomputer profile.
 #define RME_X64_FPU_TYPE             RME_X64_FPU_AVX512
 /* Timer frequency - about 1000 ticks per second */
 #define RME_X64_TIMER_FREQ           1000
+/*Debug macros*/
+#define RME_DBGLOG_ENABLE            (1U)
 /* End Define ****************************************************************/
 
 /* End Of File ***************************************************************/

--- a/Include/Platform/X64/rme_platform_x64.h
+++ b/Include/Platform/X64/rme_platform_x64.h
@@ -89,9 +89,12 @@ typedef rme_s64_t rme_ret_t;
 /* System macros *************************************************************/
 /* Compiler "extern" keyword setting */
 #define EXTERN                               extern
+#define RME_EXTERN                           extern
 /* Compiler "inline" keyword setting */
 #define INLINE                               inline
 /* Compiler likely & unlikely setting */
+#define likely(X)							 (__builtin_expect(!!(X), 1))
+#define unlikely(X)							 (__builtin_expect(!!(X), 0))
 #ifdef likely
 #define RME_LIKELY(X)                        (likely(X))
 #else
@@ -105,29 +108,51 @@ typedef rme_s64_t rme_ret_t;
 /* Get CPU-local data structure */
 #define RME_CPU_LOCAL()                      __RME_X64_CPU_Local_Get()
 /* The order of bits in one CPU machine word */
-#define RME_WORD_ORDER                       6
+#define RME_WORD_ORDER                       (6U)
 /* Forcing VA=PA in user memory segments */
-#define RME_VA_EQU_PA                        (RME_FALSE)
+#define RME_VA_EQU_PA                        (0U)
 /* Quiescence timeslice value - always 10 slices, roughly equivalent to 100ms */
-#define RME_QUIE_TIME                        10
+#define RME_QUIE_TIME                        (10U)
 /* Cpt size limit - not restricted, user-level decides this */
-#define RME_CPT_LIMIT                     0
+#define RME_CPT_LIMIT                         (0U)
 /* Normal page directory size calculation macro */
-#define RME_PGT_SIZE_NOM(NUM_ORDER)        ((1<<(NUM_ORDER))*sizeof(rme_ptr_t))
+#define RME_PGT_SIZE_NOM(NUM_ORDER)           ((1<<(NUM_ORDER))*sizeof(rme_ptr_t))
 /* Top-level page directory size calculation macro */
-#define RME_PGT_SIZE_TOP(NUM_ORDER)        RME_PGT_SIZE_NOM(NUM_ORDER)
+#define RME_PGT_SIZE_TOP(NUM_ORDER)           RME_PGT_SIZE_NOM(NUM_ORDER)
 /* Initial stack size and address */
-#define RME_KOM_STACK_ADDR                  ((rme_ptr_t)__RME_X64_Kern_Boot_Stack)
+#define RME_KOM_STACK_ADDR                    ((rme_ptr_t)__RME_X64_Kern_Boot_Stack)
 /* The virtual memory start address for the kernel objects */
-#define RME_KOM_VA_START                    0xFFFF800000000000ULL
+#define RME_KOM_VA_BASE                       0xFFFF800001600000ULL
 /* The size of the kernel object virtual memory - dummy, we will detect the actual values */
-#define RME_KOM_SIZE                        0x1000
+#define RME_KOM_VA_SIZE                       0x1000
 /* The virtual memory start address for the virtual machines - If no virtual machines is used, set to 0 */
-#define RME_HYP_VA_START                     0
-/* The size of the hypervisor reserved virtual memory */
-#define RME_HYP_SIZE                         0
+#define RME_HYP_VA_START                      (0U)
+/*User-mode page table direct management switch */
+#define RME_PGT_RAW_ENABLE                     (0U)
 /* The kernel object allocation table address - relocated */
-#define RME_KOT_VA_BASE                            ((rme_ptr_t*)0xFFFF800001000000)
+#define RME_KOT_VA_BASE						  ((rme_ptr_t*)0xFFFF800001000000)
+/* Hypervisor reserved virtual address base - when no in use ,we set it to zero */
+#define RME_HYP_VA_BASE                 	  (0U)
+/* Hypervisor reserved virtual memory size - when no in use ,we set it to zero */
+#define RME_HYP_VA_SIZE                 	  (0U)
+/* Word bits of this architecture, in x86-64, it's 64bit */
+#define RME_WORD_BITS                   	  (64U)
+/* Upper limit of preemption priority */
+#define RME_PREEMPT_PRIO_NUM         		  (64U)
+/* Timestamp of system , in x86-64 ,we use RDTSC to count time */
+#define RME_TIMESTAMP 						  __RME_Get_timestamp()
+/* Kernel object table round function */
+#define RME_KOT_VA_BASE_ROUND(x)			  RME_ROUND_UP(x,12)
+/* 2-level cap flag*/
+#define RME_CAPID_2L						  (((rme_cid_t)1)<<(sizeof(rme_ptr_t)*2-1))
+/* Get 2-level capid */
+#define RME_CAPID(X,Y)						  (((X)<<(sizeof(rme_ptr_t)*2))|(Y)|RME_CAPID_2L)
+/* VGA text area address - this is a paddr */
+#define RME_X64_VGA_BASE					  ((volatile rme_u16_t*)(RME_X64_PA2VA(0xB8000)))
+/* VGA text area settings , we create a 80*25 area */
+#define RME_X64_VGA_ROW_MAX					  (25U)
+#define RME_X64_VGA_COL_MAX					  (80U)
+
 /* Atomic instructions - The oficial release replaces all these with inline
  * assembly to boost speed. Sometimes this can harm compiler compatibility. If
  * you need normal assembly version, consider uncommenting the macro below. */
@@ -144,7 +169,7 @@ typedef rme_s64_t rme_ret_t;
 #define RME_MSB_GET(VAL)                     __RME_X64_MSB_Get(VAL)
 /* Inline assembly implementation */
 #else
-static INLINE rme_ptr_t _RME_X64_Comp_Swap(rme_ptr_t* Ptr, rme_ptr_t Old, rme_ptr_t New)
+static INLINE rme_ptr_t _RME_X64_Comp_Swap(volatile rme_ptr_t* Ptr, rme_ptr_t Old, rme_ptr_t New)
 {
 	rme_u8_t Zero;
 	__asm__ __volatile__("LOCK CMPXCHGQ %[New], %[Ptr]; SETZ %[Zero]"
@@ -153,7 +178,7 @@ static INLINE rme_ptr_t _RME_X64_Comp_Swap(rme_ptr_t* Ptr, rme_ptr_t Old, rme_pt
 	                     :"memory", "cc");
 	return (rme_ptr_t)Zero;
 }
-static INLINE rme_ptr_t _RME_X64_Fetch_Add(rme_ptr_t* Ptr, rme_cnt_t Addend)
+static INLINE rme_ptr_t _RME_X64_Fetch_Add(volatile rme_ptr_t* Ptr, rme_cnt_t Addend)
 {
 	__asm__ __volatile__("LOCK XADDQ %[Addend], %[Ptr]"
 	                     :[Ptr]"+m"(*Ptr), [Addend]"+r"(Addend)
@@ -179,6 +204,44 @@ static INLINE rme_ptr_t _RME_X64_MSB_Get(rme_ptr_t Val)
 	                     :"cc");
 	return Ret;
 }
+
+static INLINE void __RME_Int_Disable()
+{
+	__asm__ __volatile__ (
+		"cli\n\t"
+	);
+}
+
+static INLINE void __RME_Int_Enable()
+{
+	__asm__ __volatile__ (
+		"sti\n\t"
+	);
+}
+
+static INLINE rme_ptr_t __RME_User_Enter()
+{
+	rme_ptr_t Ret;
+	asm volatile (
+	"movq %1, %%rcx\n\t"
+	"movq %2, %%rsp\n\t"
+	"movq $0x3200, %%r11\n\t"
+	"movq %3, %%rdi\n\t"
+	"sysretq"
+);
+	return Ret;
+}
+
+static INLINE rme_ptr_t __RME_Get_timestamp()
+{
+    rme_u32_t lo, hi;
+    __asm__ __volatile__ (
+        "rdtsc"
+        : "=a" (lo), "=d" (hi)
+    );
+    return ((rme_ptr_t)hi << 32) | lo;
+}
+
 #define RME_COMP_SWAP(PTR,OLD,NEW)           _RME_X64_Comp_Swap(PTR,OLD,NEW)
 #define RME_FETCH_ADD(PTR,ADDEND)            _RME_X64_Fetch_Add(PTR,ADDEND)
 #define RME_FETCH_AND(PTR,OPERAND)           _RME_X64_Fetch_And(PTR,OPERAND)
@@ -230,7 +293,7 @@ static INLINE rme_ptr_t _RME_X64_MSB_Get(rme_ptr_t Val)
 #define RME_X64_VA_BASE                      (0xFFFF800000000000ULL)
 #define RME_X64_TEXT_VA_BASE                 (0xFFFFFFFF80000000ULL)
 /* The offset of kernel object table */
-#define RME_X64_KOT_OFFSET                 (0x1000000ULL)
+#define RME_X64_KOT_OFFSET                   (0x1000000ULL)
 /* The offset of device hole */
 #define RME_X64_DEVICE_OFFSET                (0xFE000000ULL)
 /* Convert PA-VA and VA-PA in the first block of memory (16MB - 3.25GB)*/
@@ -741,6 +804,36 @@ struct RME_Reg_Struct
     rme_ptr_t SS;
 };
 
+/* Exception context structure
+ * This structure holds the metadata when an exception or interrupt occurs.
+ * It supplements the general-purpose register structure by providing exception-specific info.
+ */
+struct RME_Exc_Struct
+{
+    /* The interrupt vector number that caused the trap, e.g., 14 = page fault */
+    rme_ptr_t INT_NUM;
+
+    /* The error code pushed by the CPU automatically (only for some exceptions). 
+     * For example, page fault, GPF, double fault, etc. 
+     * If not present, this is set to 0. */
+    rme_ptr_t ERROR_CODE;
+
+    /* The faulting instruction address (same as RIP in most cases) */
+    rme_ptr_t RIP;
+
+    /* Code segment selector at the time of the exception */
+    rme_ptr_t CS;
+
+    /* RFLAGS register at the time of exception, including interrupt flag, etc. */
+    rme_ptr_t RFLAGS;
+
+    /* Stack pointer at the time of exception (user/kernel depending on CPL switch) */
+    rme_ptr_t RSP;
+
+    /* Stack segment selector (only pushed if transitioning from user to kernel) */
+    rme_ptr_t SS;
+};
+
 /* The coprocessor register set structure. MMX and SSE */
 struct RME_Cop_Struct
 {
@@ -887,6 +980,7 @@ struct __RME_X64_Kern_Pgt
 	rme_ptr_t PML4[256];
 	rme_ptr_t PDP[256][512];
 };
+
 /*****************************************************************************/
 /* __RME_PLATFORM_X64_STRUCT__ */
 #endif
@@ -931,6 +1025,12 @@ static volatile rme_ptr_t RME_X64_LAPIC_Addr;
 static volatile struct RME_X64_Features RME_X64_Feature;
 /* The PCID counter */
 static volatile rme_ptr_t RME_X64_PCID_Inc;
+/* The VGA buffer pointer */
+static volatile rme_u16_t* vga_buffer;
+/* The VGA text cursor row */
+static volatile rme_ptr_t vga_row;
+/* The VGA text cursor col */
+static volatile rme_ptr_t vga_col;
 
 /* Translate the flags into X64 specific ones - the STATIC bit will never be
  * set thus no need to consider about it here. The flag bits order is shown below:
@@ -1151,6 +1251,13 @@ EXTERN void __RME_X64_IDT_Load(rme_ptr_t* IDTR);
 EXTERN void __RME_X64_TSS_Load(rme_ptr_t TSS);
 EXTERN rme_ptr_t __RME_X64_CPUID_Get(rme_ptr_t EAX, rme_ptr_t* EBX, rme_ptr_t* ECX, rme_ptr_t* EDX);
 EXTERN void __RME_X64_Pgt_Set(rme_ptr_t Pgt);
+EXTERN void __RME_Svc_Param_Get(struct RME_Reg_Struct* Reg,rme_ptr_t* Svc,rme_ptr_t* Cid,rme_ptr_t* Param);
+EXTERN void __RME_Svc_Retval_Set(struct RME_Reg_Struct* Reg,rme_ret_t Retval);
+EXTERN void __RME_Inv_Retval_Set(struct RME_Reg_Struct* Reg,rme_ret_t Retval);
+EXTERN rme_ret_t __RME_Kfn_Handler(struct RME_Cap_Cpt* Cpt,struct RME_Reg_Struct* Reg,rme_ptr_t FuncID,rme_ptr_t SubID,rme_ptr_t Param1,rme_ptr_t Param2);
+EXTERN void __RME_List_Crt(struct RME_List* Head);
+EXTERN void __RME_List_Ins(struct RME_List* New,struct RME_List* Prev,struct RME_List* Next);
+EXTERN void __RME_List_Del(struct RME_List* Prev,struct RME_List* Next);
 /* Boot glue */
 EXTERN void __RME_X64_SMP_Boot_32(void);
 /* Vectors */
@@ -1446,7 +1553,7 @@ EXTERN void ___RME_X64_Thd_Cop_Restore(struct RME_Cop_Struct* Cop_Reg);
 /* Booting */
 EXTERN void _RME_Kmain(rme_ptr_t Stack);
 EXTERN void __RME_Enter_User_Mode(rme_ptr_t Entry_Addr, rme_ptr_t Stack_Addr, rme_ptr_t CPUID);
-__EXTERN__ rme_ptr_t __RME_Low_Level_Init(void);
+__EXTERN__ rme_ptr_t __RME_Lowlvl_Init(void);
 __EXTERN__ rme_ptr_t __RME_Boot(void);
 __EXTERN__ void __RME_Reboot(void);
 __EXTERN__ void __RME_Shutdown(void);
@@ -1456,7 +1563,7 @@ __EXTERN__ void __RME_Get_Syscall_Param(struct RME_Reg_Struct* Reg, rme_ptr_t* S
                                         rme_ptr_t* Capid, rme_ptr_t* Param);
 __EXTERN__ void __RME_Set_Syscall_Retval(struct RME_Reg_Struct* Reg, rme_ret_t Retval);
 /* Thread register sets */
-__EXTERN__ void __RME_Thd_Reg_Init(rme_ptr_t Entry, rme_ptr_t Stack, rme_ptr_t Param, struct RME_Reg_Struct* Reg);
+__EXTERN__ void __RME_Thd_Reg_Init(rme_ptr_t Attr,rme_ptr_t Entry, rme_ptr_t Stack, rme_ptr_t Param, struct RME_Reg_Struct* Reg);
 __EXTERN__ void __RME_Thd_Reg_Copy(struct RME_Reg_Struct* Dst, struct RME_Reg_Struct* Src);
 __EXTERN__ void __RME_Thd_Cop_Init(struct RME_Reg_Struct* Reg, struct RME_Cop_Struct* Cop_Reg);
 __EXTERN__ void __RME_Thd_Cop_Save(struct RME_Reg_Struct* Reg, struct RME_Cop_Struct* Cop_Reg);
@@ -1474,7 +1581,7 @@ __EXTERN__ void __RME_X64_Fault_Handler(struct RME_Reg_Struct* Reg, rme_ptr_t Re
 /* Generic interrupt handler */
 __EXTERN__ void __RME_X64_Generic_Handler(struct RME_Reg_Struct* Reg, rme_ptr_t Int_Num);
 /* Page table operations */
-__EXTERN__ void __RME_Pgt_Set(rme_ptr_t Pgt);
+__EXTERN__ void __RME_Pgt_Set(struct RME_Cap_Pgt* Pgt);
 __EXTERN__ rme_ptr_t __RME_Pgt_Kom_Init(void);
 __EXTERN__ rme_ptr_t __RME_Pgt_Check(rme_ptr_t Base_Addr, rme_ptr_t Is_Top, rme_ptr_t Size_Order, rme_ptr_t Num_Order, rme_ptr_t Vaddr);
 __EXTERN__ rme_ptr_t __RME_Pgt_Init(struct RME_Cap_Pgt* Pgt_Op);

--- a/Include/Platform/X64/rme_platform_x64.ld
+++ b/Include/Platform/X64/rme_platform_x64.ld
@@ -12,7 +12,14 @@ ENTRY(_start)
 __RME_X64_Mboot_Load_Addr = 0x00100000;
 
 SECTIONS
-{   
+{
+/*
+    . = 0xFFFFFFFF20000000;
+    .rodata : AT(0x10000000) {
+               *UVM.o(.rodata .rodata.*)
+              }
+*/
+
 	/* Link the kernel at this address: "." means the current address */
     /* Must be equal to KERNLINK */
 	. = 0xFFFFFFFF80100000;
@@ -20,7 +27,7 @@ SECTIONS
 	PROVIDE(begin = .);
 
 	.text : AT(__RME_X64_Mboot_Load_Addr) {
-	    *platform_x64_asm.o(.text .rela.text .stub .text.* .gnu.linkonce.t.*)
+	    *platform_x64_gcc.o(.multiboot_head .text .rela.text .stub .text.* .gnu.linkonce.t.*)
 		*(.text .rela.text .stub .text.* .gnu.linkonce.t.*)
 	}
 	
@@ -49,17 +56,13 @@ SECTIONS
 	. = ALIGN(0x1000);
 
 	PROVIDE(edata = .);
-	
+
     . = ALIGN(0x1000);
 
 	.bss : {
-		*rme_captbl.o(.bss)
         *rme_kernel.o(.bss)
-        *rme_pgtbl.o(.bss)
-        *rme_prcthd.o(.bss)
-        *rme_siginv.o(.bss)
         *rme_platform_x64.o(.bss)
-        *rme_platform_x64_asm.o(.bss)
+        *rme_platform_x64_gcc.o(.bss)
 		*(COMMON)
 	}
 
@@ -67,13 +70,9 @@ SECTIONS
 	
     /* This mapping starts from 16MB, and includes all the kernel memory
      * that should not be touched by grub. We init it when we run our kernel */
-	. = 0xFFFFFFFF81000000;
-    .noinit : {
-        *rme_kotbl.o(.bss)
-    }
 
 	/DISCARD/ : {
-		*(.eh_frame .rela.eh_frame .note.GNU-stack)
+		*(.eh_frame .rela.eh_frame .note.*)
 	}
 }
 

--- a/Include/Platform/X64/rme_platform_x64_conf.h
+++ b/Include/Platform/X64/rme_platform_x64_conf.h
@@ -7,7 +7,7 @@ Description: The configuration file for x64 profile settings.
 ******************************************************************************/
 
 /* Config Includes ***********************************************************/
-#include "Platform/X64/Profiles/Super/rme_platform_X64_SUPER.h"
+#include "Platform/X64/Profile/Super/rme_platform_x64_super.h"
 /* End Config Includes *******************************************************/
 
 /* End Of File ***************************************************************/

--- a/Project/VSCODE-GCC-X64/Makefile
+++ b/Project/VSCODE-GCC-X64/Makefile
@@ -1,0 +1,67 @@
+# Config ######################################################################
+TARGET=RME
+CPU=-m64
+
+CC=gcc
+CFLAGS=-O2 -mcmodel=kernel -static -fmessage-length=0 -ffreestanding -fno-pic -fno-builtin -fno-strict-aliasing -fno-common -nostdlib -fno-stack-protector -mtls-direct-seg-refs -mno-red-zone
+WFLAGS=-Wall
+DFLAGS=-g3
+LDFLAGS=-T ../../Include/Platform/X64/rme_platform_x64.ld -static -ffreestanding -fno-pic -fno-builtin -fno-strict-aliasing -fno-common -nostdlib -Wl,--build-id=none -fno-stack-protector -z noexecstack
+OBJDIR=Object
+# End Config ##################################################################
+
+# Source ######################################################################
+INCS+=-I.
+INCS+=-I/usr/include/x86_64-linux-gnu
+INCS+=-I../../Include
+
+CSRCS+=./UVM.c
+CSRCS+=../../Source/Kernel/rme_kernel.c
+CSRCS+=../../Source/Platform/X64/rme_platform_x64.c
+ASRCS+=../../Source/Platform/X64/rme_platform_x64_gcc.s
+LIBS=-lpthread
+# End Source ##################################################################
+
+# User ########################################################################
+-include user
+# End User ####################################################################
+
+# Build #######################################################################
+COBJS+=$(CSRCS:%.c=%.o)
+COBJS+=$(ASRCS:%.s=%.o)
+CDEPS=$(CSRCS:%.c=%.d)
+
+DEP=$(OBJDIR)/$(notdir $(@:%.o=%.d))
+OBJ=$(OBJDIR)/$(notdir $@)
+
+# Build all
+all: mkdir $(COBJS) $(TARGET)
+
+# Create output folder
+mkdir:
+	$(shell if [ ! -e $(OBJDIR) ];then mkdir -p $(OBJDIR); fi)
+
+# Compile C sources
+%.o:%.c
+	@echo "    CC      $(notdir $<)"
+	@$(CC) -c $(CPU) $(INCS) $(CFLAGS) $(DFLAGS) $(WFLAGS) -MMD -MP -MF "$(DEP)" "$<" -o "$(OBJ)";
+
+#Assemble asm file
+%.o: %.s
+	@echo "    AS      $(notdir $<)"
+	@$(CC) -c $(CPU) $(INCS) $(CFLAGS) $(DFLAGS) $(WFLAGS) -MMD -MP -MF "$(DEP)" "$<" -o "$(OBJ)"
+
+$(TARGET): $(COBJS)
+	@echo "    BIN     $(notdir $@)"
+	@$(CC) $(OBJDIR)/*.o $(CPU) $(LIBS) $(LDFLAGS) -o $(OBJ)
+
+# Clean up
+.PHONY: clean
+clean:
+	-rm -rf $(OBJDIR)
+
+# Dependencies
+-include $(wildcard $(OBJDIR)/*.d)
+# End Build ###################################################################
+
+# End Of File #################################################################

--- a/Project/VSCODE-GCC-X64/iso_crt.sh
+++ b/Project/VSCODE-GCC-X64/iso_crt.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cp -f ./Object/RME ./isofiles/boot/
+grub-mkrescue -o RME.iso isofiles
+objdump -S ./Object/RME > RME.asm

--- a/Project/VSCODE-GCC-X64/isofiles/boot/grub/grub.cfg
+++ b/Project/VSCODE-GCC-X64/isofiles/boot/grub/grub.cfg
@@ -1,0 +1,7 @@
+set timeout=10
+set default=0
+
+menuentry "RME Microkernel" {
+multiboot /boot/RME
+boot
+}

--- a/Project/VSCODE-GCC-X64/make_kernel.sh
+++ b/Project/VSCODE-GCC-X64/make_kernel.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cp -f ./Benchmark/UVM.c ./UVM.c
+make clean && make

--- a/Project/VSCODE-GCC-X64/qemu_test.sh
+++ b/Project/VSCODE-GCC-X64/qemu_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# typical desktop system, 1 numa node, 1 socket, 1 processors, 4GB RAM */
+qemu-system-x86_64 -serial stdio -net none -smp 1 -cpu EPYC-v2 -m 4096 -cdrom ./RME.iso -monitor none -D qemu-log.txt -nographic

--- a/Project/VSCODE-GCC-X64/rme_platform.h
+++ b/Project/VSCODE-GCC-X64/rme_platform.h
@@ -1,0 +1,15 @@
+/******************************************************************************
+Filename    : rme_platform.h
+Author      : pry 
+Date        : 11/10/2017
+Licence     : LGPL v3+; see COPYING for details.
+Description : The platform specific types for RME.。
+******************************************************************************/
+
+/* Platform Includes *********************************************************/
+#include "Platform/X64/rme_platform_x64.h"
+/* End Platform Includes *****************************************************/
+
+/* End Of File ***************************************************************/
+
+/* Copyright (C) Evo-Devo Instrum. All rights reserved ***********************/

--- a/README.md
+++ b/README.md
@@ -300,4 +300,5 @@ We ask what fits the situation, rather than what is at hand.
 
 ### Starring Contributors
 - Junwen Huang - ARM v7-A port
+- Kevin  Hua   - X86-64	  port
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -300,3 +300,5 @@ Click **[HERE](README.md)** for English version.
 
 ### 杰出贡献者
 - 黄隽文 - ARM v7-A 的移植支持
+- 华楷文 - X86-64 的移植支持
+

--- a/Source/Kernel/rme_kernel.c
+++ b/Source/Kernel/rme_kernel.c
@@ -4533,7 +4533,7 @@ static void _RME_Run_Notif(struct RME_Thd_Struct* Thd)
     }
 
     /* If this guy have an endpoint, send to it */
-    if(Thd->Sched.Sched_Sig!=0U)
+    if(Thd->Sched.Sched_Sig!=RME_NULL)
     {
         RME_COV_MARKER();
         _RME_Kern_Snd(Thd->Sched.Sched_Sig,1U);
@@ -5678,7 +5678,7 @@ static rme_ret_t _RME_Thd_Sched_Bind(struct RME_Cap_Cpt* Cpt,
                (Thread->Sched.State==RME_THD_EXCPEND));
 
     /* Tie the signal endpoint to it if not zero */
-    if(Sig_Op==0U)
+    if(Sig_Op==RME_NULL)
     {
         RME_COV_MARKER();
 
@@ -6861,7 +6861,7 @@ static rme_ret_t _RME_Sig_Del(struct RME_Cap_Cpt* Cpt,
     RME_CAP_DEL_CHECK(Sig_Del,Type_Stat,RME_CAP_TYPE_SIG);
 
     /* Check if the signal endpoint is currently used and cannot be deleted */
-    if(RME_UNLIKELY(Sig_Del->Thd!=0U))
+    if(RME_UNLIKELY(Sig_Del->Thd!=RME_NULL))
     {
         RME_COV_MARKER();
 

--- a/Source/Platform/X64/rme_platform_x64_gcc.s
+++ b/Source/Platform/X64/rme_platform_x64_gcc.s
@@ -141,7 +141,7 @@ AVX-512 registers:
     /* The system call handler of RME. This will be defined in C language. */
     .global             _RME_Svc_Handler
     /* The system tick handler of RME. This will be defined in C language. */
-    .global             _RME_Tick_Handler
+    .global             _RME_Tim_Handler
     /* The entry of SMP after they have finished their initialization */
     .global             __RME_SMP_Low_Level_Init
     /* All other processor's timer interrupt handler */
@@ -277,12 +277,10 @@ Boot_High_64:
     /* Pass the physical address of RSI to it */
     MOV                 %RSI,%RDI
     JMP                 main
-    JMP                 .
 Boot_SMP_64:
     MOV                 $0x7000,%RAX
     MOV                 -16(%RAX),%RSP
     JMP                 __RME_SMP_Low_Level_Init
-    JMP                 .
 
     /* The initial gdt. Later we will have one GDT per CPU */
     .align              16
@@ -1049,7 +1047,7 @@ SysTick_Handler:
     SAVE_GP_REGS
     /* Pass the stack pointer to system call handler */
     MOVQ                %RSP,%RDI
-    CALLQ               _RME_Tick_Handler
+    CALLQ               _RME_Tim_Handler
     CALLQ               __RME_X64_SMP_Tick
     CALLQ               __RME_X64_LAPIC_Ack
     RESTORE_GP_REGS
@@ -1113,6 +1111,9 @@ Use_IRET:
     ADDQ                $16,%RSP
     IRETQ
 /* End Function:SVC_Handler **************************************************/
+
+_RME_Tick_SMP_Handler:
+/*Empty for now*/
 
 ;/* End Of File **************************************************************/
 


### PR DESCRIPTION
### Description of the Change
The code has been initially ported to the x86-64 architecture, along with a basic round of performance testing. This includes:
✅Adapting key structures and assembly code for x64
✅Successfully booting on both emulator and physical hardware(only support single-core startup now)
✅Implementing and executing benchmark tests for thread-switch performance

Additionally, some modifications were made to the kernel code:
💚Minor modifications to the kernel code to eliminate warnings related to type conversions

